### PR TITLE
Updating the url for code examples in arjs documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -172,7 +172,7 @@ There is a [Codepen](https://codepen.io/nicolocarpignoli/pen/vYOeYKd) for you to
 
 Please follow these simple steps:
 
-- Create a new project with the code below (or [open this live example](https://ar-js-org.github.io/AR.js/aframe/examples/image-tracking/nft/) and go directly to the last step)
+- Create a new project with the code below (or [open this live example](https://ar-js-org.github.io/.github/profile/aframe/examples/image-tracking/nft/) and go directly to the last step)
 - Run it on a server
 - Open the website on your phone
 - Scan [this picture](https://raw.githack.com/AR-js-org/AR.js/master/aframe/examples/image-tracking/nft/trex-image-big.jpeg) to see content through the camera.
@@ -278,7 +278,7 @@ This is just a basic example and most location-based applications will involve J
 
 Please follow these simple steps:
 
-- Create a new project with the code below (or [open this live example](https://ar-js-org.github.io/AR.js/aframe/examples/marker-based/basic.html) and go directly to the last step)
+- Create a new project with the code below (or [open this live example](https://ar-js-org.github.io/.github/profile/aframe/examples/marker-based/basic.html) and go directly to the last step)
 - Run it on a server
 - Open the website on your phone
 - Scan [this picture](https://raw.githubusercontent.com/AR-js-org/AR.js/master/data/images/hiro.png) to see content through the camera.


### PR DESCRIPTION
Updated the live example URLs in documentation based on the [fix for closed issue](https://github.com/AR-js-org/AR.js/issues/529). 

Should close issues:
- [ #569 in AR.js](https://github.com/AR-js-org/AR.js/issues/569) (I have tested on Firefox browser on Android)
- [ #551 in AR.js](https://github.com/AR-js-org/AR.js/issues/569)
